### PR TITLE
Add resume generation pipeline

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,0 +1,35 @@
+import os
+from contextlib import contextmanager
+import psycopg2
+from psycopg2.pool import SimpleConnectionPool
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable is required")
+
+pool = SimpleConnectionPool(minconn=1, maxconn=5, dsn=DATABASE_URL)
+
+@contextmanager
+def get_conn():
+    conn = pool.getconn()
+    try:
+        yield conn
+    finally:
+        pool.putconn(conn)
+
+def fetch_job_urls(limit=10):
+    """Return a list of (id, url) tuples from the jobs table."""
+    query = "SELECT id, url FROM jobs WHERE url IS NOT NULL LIMIT %s"
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (limit,))
+            return cur.fetchall()
+
+def store_job_page(job_id, html, requirements_text):
+    """Store downloaded HTML and extracted requirements for a job."""
+    query = "UPDATE jobs SET page_html=%s, requirements=%s WHERE id=%s"
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (html, requirements_text, job_id))
+            conn.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ langchain_openai
 sqlalchemy
 tenacity
 matplotlib
+psycopg2-binary
+requests
+beautifulsoup4

--- a/resume_generator.py
+++ b/resume_generator.py
@@ -1,0 +1,17 @@
+import os
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+PROMPT = (
+    "You are a helpful assistant that rewrites a resume to match a job description." 
+    "Return the improved resume in plain text."
+)
+
+def generate_resume(resume_text: str, job_requirements: str) -> str:
+    messages = [
+        {"role": "system", "content": PROMPT},
+        {"role": "user", "content": f"Resume:\n{resume_text}\n\nJob requirements:\n{job_requirements}"},
+    ]
+    resp = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    return resp.choices[0].message.content.strip()

--- a/resume_parser.py
+++ b/resume_parser.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+def load_resume(path: str) -> str:
+    """Load resume text from a file."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(path)
+    return p.read_text()

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,0 +1,25 @@
+import os
+from database import fetch_job_urls, store_job_page
+from scraper import download_job_page, parse_requirements
+from resume_parser import load_resume
+from resume_generator import generate_resume
+
+RESUME_PATH = os.getenv("RESUME_PATH", "resume.txt")
+
+
+def main():
+    resume_text = load_resume(RESUME_PATH)
+    jobs = fetch_job_urls(limit=1)
+    for job_id, url in jobs:
+        html = download_job_page(url)
+        reqs = parse_requirements(html)
+        new_resume = generate_resume(resume_text, reqs)
+        store_job_page(job_id, html, reqs)
+        out_file = f"resume_{job_id}.txt"
+        with open(out_file, "w") as f:
+            f.write(new_resume)
+        print(f"Generated resume for job {job_id} -> {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,26 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import Tuple
+
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+def download_job_page(url: str) -> str:
+    resp = requests.get(url, headers=HEADERS, timeout=10)
+    resp.raise_for_status()
+    return resp.text
+
+def parse_requirements(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    # Simple heuristic: extract bullet lists under sections containing 'requirement'
+    sections = soup.find_all(text=lambda t: t and 'require' in t.lower())
+    if not sections:
+        return ""
+    # Gather sibling lists or paragraphs
+    requirements = []
+    for s in sections:
+        parent = s.parent
+        ul = parent.find_next("ul")
+        if ul:
+            items = [li.get_text(" ", strip=True) for li in ul.find_all("li")]
+            requirements.extend(items)
+    return "\n".join(requirements)

--- a/test_openai_api.py
+++ b/test_openai_api.py
@@ -1,49 +1,30 @@
 #!/usr/bin/env python3
 import os
-import sys
+import pytest
 
 try:
     import openai
-except ImportError:
-    print("Please install the OpenAI library first:\n    pip install openai")
-    sys.exit(1)
+except ImportError:  # pragma: no cover - dependency missing
+    openai = None
+
 
 def test_openai_api():
-    # 1. Load API key
+    if openai is None:
+        pytest.skip("openai package not installed")
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        print("ERROR: OPENAI_API_KEY environment variable is not set.")
-        return False
+        pytest.skip("OPENAI_API_KEY not configured")
 
     openai.api_key = api_key
+    resp = openai.models.list()
+    assert hasattr(resp, "data")
 
-    # 2. Try to list models using the new API
-    try:
-        print("Listing models…")
-        resp = openai.models.list()
-        # resp is a SyncPage of Model objects, so use .data
-        models = resp.data  
-        print(f"✅ Successfully retrieved {len(models)} models.")
-    except Exception as e:
-        print(f"❌ Failed to list models: {e}")
-        return False
-
-    # 3. Send a quick chat completion
-    try:
-        print("Sending test completion…")
-        chat = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",  # widely available model
-            messages=[{"role": "user", "content": "Say hello in one word."}],
-            temperature=0
-        )
-        content = chat.choices[0].message.content.strip()
-        print(f"✅ Completion succeeded: “{content}”")
-    except Exception as e:
-        print(f"❌ Chat completion failed: {e}")
-        return False
-
-    return True
+    chat = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "Say hello in one word."}],
+        temperature=0,
+    )
+    assert chat.choices[0].message.content
 
 if __name__ == "__main__":
-    success = test_openai_api()
-    sys.exit(0 if success else 1)
+    test_openai_api()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,13 @@
+from scraper import parse_requirements
+
+sample_html = """
+<html><body>
+<h2>Job Requirements</h2>
+<ul><li>Python</li><li>SQL</li></ul>
+</body></html>
+"""
+
+def test_parse_requirements():
+    text = parse_requirements(sample_html)
+    assert "Python" in text
+    assert "SQL" in text


### PR DESCRIPTION
## Summary
- expand requirements with scraping and database libraries
- add PostgreSQL helper module
- build basic web scraper
- add resume loading and generation
- wire pipeline script
- adjust OpenAI test to skip without API key
- test scraper parser

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bf9faa88833087f70869f2af350f